### PR TITLE
Fixed hide-workspace plugin error: variable not found

### DIFF
--- a/hide-workspace@xenatt.github.com/extension.js
+++ b/hide-workspace@xenatt.github.com/extension.js
@@ -12,10 +12,8 @@ const hideVisible = new Lang.Class({
 	Name: 'hideWorkspace.hideVisible',
 
 	_init: function() {
-		//old solution
-		//thumbnailsBoxOp = Main.overview._controls._thumbnailsSlider.actor.opacity;
-		var tmp_getAlwaysZoomOut = ThumbnailsSlider._getAlwaysZoomOut;
-		var tmp_getNonExpandedWidth = ThumbnailsSlider.getNonExpandedWidth;
+		this.tmp_getAlwaysZoomOut = ThumbnailsSlider._getAlwaysZoomOut;
+		this.tmp_getNonExpandedWidth = ThumbnailsSlider.getNonExpandedWidth;
 	},
 
 	enable: function() {
@@ -24,7 +22,7 @@ const hideVisible = new Lang.Class({
 	},
 
 	disable: function() {
-		ThumbnailsSlider._getAlwaysZoomOut = tmp_getAlwaysZoomOut;
-		ThumbnailsSlider.getNonExpandedWidth = tmp_getNonExpandedWidth;
+		ThumbnailsSlider._getAlwaysZoomOut = this.tmp_getAlwaysZoomOut;
+		ThumbnailsSlider.getNonExpandedWidth = this.tmp_getNonExpandedWidth;
 	}
 });

--- a/hide-workspace@xenatt.github.com/extension.js
+++ b/hide-workspace@xenatt.github.com/extension.js
@@ -6,7 +6,7 @@ const ThumbnailsSlider = imports.ui.overviewControls.ThumbnailsSlider.prototype;
 
 const init = function () {
 	return new hideVisible();
-}
+};
 
 const hideVisible = new Lang.Class({
 	Name: 'hideWorkspace.hideVisible',
@@ -17,8 +17,8 @@ const hideVisible = new Lang.Class({
 	},
 
 	enable: function() {
-		ThumbnailsSlider._getAlwaysZoomOut = function () { return false; }
-		ThumbnailsSlider.getNonExpandedWidth = function () { return 0; }
+		ThumbnailsSlider._getAlwaysZoomOut = function () { return false; };
+		ThumbnailsSlider.getNonExpandedWidth = function () { return 0; };
 	},
 
 	disable: function() {


### PR DESCRIPTION
After installing Ubuntu 17.04 I noticed that plugin hide-workspace sometimes work, and sometimes don't. I did small investigation and in my syslog I noticed error:

```
Extension "hide-workspace@xenatt.github.com" had error:
ReferenceError: tmp_getAlwaysZoomOut is not defined
```
So after finding plugin source code I made some adjustments as you can see in this pull request, also while doing that I added some missing semicolons :)

