### PR TITLE
Update hide-dash for 3.36 and small improvements.

### DIFF
--- a/hide-dash@xenatt.github.com/extension.js
+++ b/hide-dash@xenatt.github.com/extension.js
@@ -2,10 +2,20 @@ const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const Lang = imports.lang;
 const Main = imports.ui.main;
+const Config = imports.misc.config;
 
+function ShellVersionMatch(version) {
+	let match = false;
+	try {
+		match = Config.PACKAGE_VERSION.match(new RegExp(`^${version}`)) !== null;
+	} catch(error) {
+		log('hide-dash | could not get shell version!');
+	}
+	return match;
+};
 
 // extension functions
-const init = function() {
+function init() {
 	return new dashVisible();
 }
 
@@ -14,36 +24,72 @@ const dashVisible = new Lang.Class({
 
 	_init: function() {
 		this.observer = null;
+		this.isNewVersion = false;
+
+		// log('hide-dash init | shell version: ' + Config.PACKAGE_VERSION);
+		if (ShellVersionMatch('3.36')) {
+			this._dash = Main.overview.dash;
+			this.isNewVersion = true;
+		} else if (ShellVersionMatch('3.34')) {
+			this._dash = Main.overview._dash;
+			this.isNewVersion = true;
+		} else {
+			this._dash = Main.overview._dash;
+		}
 
 		// store the values we are going to override
-		this.old_x = Main.overview.viewSelector.actor.x;
-		this.old_width = Main.overview.viewSelector.actor.get_width();
+		if (this.isNewVersion) {
+			this.old_x = Main.overview.viewSelector.x;
+			this.old_width = Main.overview.viewSelector.get_width();
+		} else {
+			this.old_x = Main.overview.viewSelector.actor.x;
+			this.old_width = Main.overview.viewSelector.actor.get_width();
+		}
+		// log('hide-dash init | x: ' + this.old_x + ' | width: ' + this.old_width);
 	},
 
 	enable: function() {
-		// global.log("enable hide-dash");
+		// log("hide-dash enable");
 		this.observer = Main.overview.connect("showing", Lang.bind(this, this._hide));
 	},
 
 	disable: function() {
-		// global.log("disable hide-dash");
+		// log("hide-dash disable");
 		Main.overview.disconnect(this.observer);
 		this._show();
 	},
 
 	_hide: function() {
-		// global.log("show dash");
-		Main.overview._dash.actor.hide();
-		Main.overview.viewSelector.actor.set_x(0);
-		Main.overview.viewSelector.actor.set_width(0);
-		Main.overview.viewSelector.actor.queue_redraw();
+		// log("hide-dash hide");
+		if (this._dash) {
+			if (this.isNewVersion) {
+				this._dash.hide();
+				Main.overview.viewSelector.set_x(0);
+				Main.overview.viewSelector.set_width(0);
+				Main.overview.viewSelector.queue_redraw();
+			} else {
+				this._dash.actor.hide();
+				Main.overview.viewSelector.actor.set_x(0);
+				Main.overview.viewSelector.actor.set_width(0);
+				Main.overview.viewSelector.actor.queue_redraw();
+			}
+		}
 	},
 
 	_show: function() {
-		// global.log("hide dash");
-		Main.overview._dash.actor.show();
-		Main.overview.viewSelector.actor.set_x(this.old_x);
-		Main.overview.viewSelector.actor.set_width(this.old_width);
-		Main.overview.viewSelector.actor.queue_redraw();
+		// log("hide-dash show");
+		if (this._dash) {
+			if (this.isNewVersion) {
+				this._dash.show();
+				Main.overview.viewSelector.set_x(this.old_x);
+				Main.overview.viewSelector.set_width(this.old_width);
+				Main.overview.viewSelector.queue_redraw();
+			} else {
+				this._dash.actor.show();
+				Main.overview.viewSelector.actor.set_x(this.old_x);
+				Main.overview.viewSelector.actor.set_width(this.old_width);
+				Main.overview.viewSelector.actor.queue_redraw();
+			}
+		}
 	}
 });

--- a/hide-dash@xenatt.github.com/metadata.json
+++ b/hide-dash@xenatt.github.com/metadata.json
@@ -1,17 +1,19 @@
 {
 	"description": "Hide the dash from the activities overview.",
-	"name": "Hide Dash X",
-	"shell-version": [
-		"3.10",
-		"3.12",
-		"3.14",
-		"3.16",
-		"3.18",
-		"3.20",
-		"3.22"
-	],
-	"url": "https://github.com/Edenhofer/Minimalism-Gnome-Shell",
-	"uuid": "hide-dash@xenatt.github.com",
+  "name": "Hide Dash X",
+  "shell-version": [
+    "3.10",
+    "3.12",
+    "3.14",
+    "3.16",
+    "3.18",
+    "3.20",
+    "3.22",
+    "3.34",
+    "3,36"
+  ],
+  "url": "https://github.com/Edenhofer/Minimalism-Gnome-Shell",
+  "uuid": "hide-dash@xenatt.github.com",
 	"original-author": "zacbarton",
 	"version": 1
 }


### PR DESCRIPTION
1. Works on 3.36 (tested on 3.36.4 - fix #9)
2. Fixed log spamming on 3.34 and 3.36
3. Logs to Gnome Shell journal
4. It should still work with old versions of Gnome Shell (not tested)